### PR TITLE
Fix actions deprecation warnings

### DIFF
--- a/.github/workflows/build-release-dictionaries.yaml
+++ b/.github/workflows/build-release-dictionaries.yaml
@@ -22,7 +22,7 @@ jobs:
           bash build_dicts.sh
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: dst/*
           tag_name: ${{ steps.date.outputs.date }}

--- a/.github/workflows/build-release-dictionaries.yaml
+++ b/.github/workflows/build-release-dictionaries.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "{name}=date::$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Run Build Dicts Script
         run: |

--- a/.github/workflows/build-release-dictionaries.yaml
+++ b/.github/workflows/build-release-dictionaries.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "{name}=date::$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Run Build Dicts Script
         run: |


### PR DESCRIPTION
Test run with these changes:
https://github.com/Kuuuube/jmdict-yomitan/actions/runs/9881261359/job/27291660673
https://github.com/Kuuuube/jmdict-yomitan/releases/tag/2024-07-10

Github docs on this:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter