### PR TITLE
Add JMdict English Without Proper Names support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tmp
 binaries
 
 JMdict.gz
+JMdict_b.gz
 JMdict_e_examp.gz
 JMnedict.xml.gz
 kanjidic2.xml.gz

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ This repository is automatically updated daily and the dictionary files are buil
   - [KANJIDIC for Yomitan](#kanjidic-for-yomitan)
 - [FAQ](#faq)
   - [Legacy vs Extra/Regular JMdict](#legacy-vs-extraregular-jmdict)
+  - [JMdict English vs JMdict English Without Proper Names](#jmdict-english-vs-jmdict-english-without-proper-names)
   - [How Often Should I Update?](#how-often-should-i-update)
   - [漢字使い参考 vs JMdict Forms](#漢字使い参考-vs-jmdict-forms)
 - [Acknowledgements](#acknowledgements)
@@ -36,7 +37,11 @@ To see your current version of JMdict, hover over this entry:
   - [JMdict_english.zip](https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/JMdict_english.zip)
     - This is the same JMdict but without example sentences.
   - [JMdict_english_legacy.zip](https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/JMdict_english_legacy.zip)
-    - This is JMdict with legacy formatting. It is not recommended for use; see the FAQ below.
+    - This is JMdict with legacy formatting. It is not recommended for use; see the [FAQ](#legacy-vs-extraregular-jmdict) below.
+  - [JMdict_english_without_proper_names.zip](https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/JMdict_english_without_proper_names.zip)
+    - This is `JMdict_english` but without several thousand entries from JMnedict. Recommended if you are using JMdict and JMnedict together; see the [FAQ](#jmdict-english-vs-jmdict-english-without-proper-names) below.
+  - [JMdict_english_legacy_without_proper_names.zip](https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/JMdict_english_legacy_without_proper_names.zip)
+    - This is `JMdict_english_without_proper_names` but with the legacy formatting of `JMdict_english_legacy`.
 - JMdict (Other Languages)
   - [JMdict_dutch.zip](https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/JMdict_dutch.zip)
   - [JMdict_french.zip](https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/JMdict_french.zip)
@@ -68,6 +73,16 @@ To see your current version of JMdict, hover over this entry:
 The legacy JMdict for Yomitan is a version of JMdict for Yomichan with legacy formatting and with lots of information missing. The so-called "extra" version of JMdict was [introduced by stephenmk](https://github.com/FooSoft/yomichan-import/pull/40) to modernize the formatting and add vital missing information such as notes, type information, source languages, references, antonyms, other forms, and more.
 
 The terminology of "Extra" is confusing since it implies that the extra version is a marginal improvement to the legacy version, so we will just call it the "regular" JMdict. The legacy version is available for download as some third-party apps do not yet support new structured-content features, but we recommend using the regular version if possible as you will be missing out on a lot of important information otherwise.
+
+### JMdict English vs JMdict English Without Proper Names
+
+If you are using JMDict English and JMnedict together, it is recommended to use `JMdict_english_without_proper_names`.
+
+[Starting in 2023](https://github.com/JMdictProject/JMdictIssues/issues/94), JMdict began copying a subset of entries from JMnedict (~10k as of 2026) into its dictionary file as part of the default distribution process for JMdict English. As a result, if you are using both JMdict English and JMnedict in Yomitan and look up a proper name that has been copied over, such as 三貴, you will get duplicate results from both dictionaries.
+
+To solve this issue, a version of JMDict English without proper names is provided here that is built from a variation of JMdict English that skips partially copying entries from JMnedict (`JMdict_b` from [EDRDG](https://www.edrdg.org/wiki/Main_Page.html#Current_Version_&_Downloads)). Other languages are not affected, so do not have additional variations provided.
+
+However, an equivalent to `JMdict_english_with_examples` but without any JMnedict entries is not provided here as EDRDG does not currently publish a version of `JMdict_b` with examples to use as a source for it.
 
 ### How Often Should I Update?
 

--- a/src/build_dicts.sh
+++ b/src/build_dicts.sh
@@ -26,6 +26,10 @@ function refresh_source () {
 refresh_source "JMdict_e_examp"
 ./binaries/yomitan -language="english_extra" -title="JMdict" data/JMdict_e_examp dst/JMdict_english_with_examples.zip
 
+refresh_source "JMdict_b"
+./binaries/yomitan -language="english_extra" -format="edict" -title="JMdict"          data/JMdict_b dst/JMdict_english_without_proper_names.zip
+./binaries/yomitan -language="english"       -format="edict" -title="JMdict (Legacy)" data/JMdict_b dst/JMdict_english_legacy_without_proper_names.zip
+
 refresh_source "JMdict"
 ./binaries/yomitan -language="english_extra" -title="JMdict"         data/JMdict dst/JMdict_english.zip
 ./binaries/yomitan -language="english"   -title="JMdict (Legacy)"    data/JMdict dst/JMdict_english_legacy.zip


### PR DESCRIPTION
## Changes

Addresses #18 

Notes about the changes:

- Dictionary format has to be explicitly provided as `yomitan-import` does not have automatic detection for `JMdict_b`
- `.gitignore` was updated as a new file gets downloaded as part of the build process now
- README was updated to add links to the new dictionary [once published), explanations of it, and a FAQ entry for more context
- Added a link to the relevant FAQ entry for the other (not changed here, but right above the line I added) JMdict English entry, to be more explicit about the section they should reference

## Testing

I tested this out locally (WSL), with this as the local output:

```
jmdict-yomitan# src/build_dicts.sh
Unable to convert ISO 639 code lao to its full name in language eng
Unable to convert ISO 639 code lao to its full name in language eng
Unable to convert ISO 639 code arm to its full name in language eng
Unable to convert ISO 639 code ben to its full name in language eng
Unable to convert ISO 639 code kaz to its full name in language eng
Unable to convert ISO 639 code div to its full name in language eng
Unable to convert ISO 639 code tgk to its full name in language eng
Unable to convert ISO 639 code alb to its full name in language eng
Unable to convert ISO 639 code aze to its full name in language eng
Unable to convert ISO 639 code tuk to its full name in language eng
Unable to convert ISO 639 code mlg to its full name in language eng
Unable to convert ISO 639 code sot to its full name in language eng
Unable to convert ISO 639 code smo to its full name in language eng
Unable to convert ISO 639 code kir to its full name in language eng
Unable to convert ISO 639 code lao to its full name in language eng
Unable to convert ISO 639 code lao to its full name in language eng
Unable to convert ISO 639 code arm to its full name in language eng
Unable to convert ISO 639 code ben to its full name in language eng
Unable to convert ISO 639 code kaz to its full name in language eng
Unable to convert ISO 639 code div to its full name in language eng
Unable to convert ISO 639 code tgk to its full name in language eng
Unable to convert ISO 639 code alb to its full name in language eng
Unable to convert ISO 639 code aze to its full name in language eng
Unable to convert ISO 639 code tuk to its full name in language eng
Unable to convert ISO 639 code mlg to its full name in language eng
Unable to convert ISO 639 code sot to its full name in language eng
Unable to convert ISO 639 code smo to its full name in language eng
Unable to convert ISO 639 code kir to its full name in language eng
Unable to convert ISO 639 code lao to its full name in language eng
Unable to convert ISO 639 code lao to its full name in language eng
Unable to convert ISO 639 code arm to its full name in language eng
Unable to convert ISO 639 code ben to its full name in language eng
Unable to convert ISO 639 code kaz to its full name in language eng
Unable to convert ISO 639 code div to its full name in language eng
Unable to convert ISO 639 code tgk to its full name in language eng
Unable to convert ISO 639 code alb to its full name in language eng
Unable to convert ISO 639 code aze to its full name in language eng
Unable to convert ISO 639 code tuk to its full name in language eng
Unable to convert ISO 639 code mlg to its full name in language eng
Unable to convert ISO 639 code sot to its full name in language eng
Unable to convert ISO 639 code smo to its full name in language eng
Unable to convert ISO 639 code kir to its full name in language eng
jmdict-yomitan#
```

<img width="347" height="642" alt="image" src="https://github.com/user-attachments/assets/71130fa1-40ab-45ea-88d7-8c1ef528075d" />

The ISO code conversion messages seem to be unrelated to my changes?

I functionally tested the new JMdict variation locally in Yomitan. I modified its index.json just so I could import it in addition to my current JMdict import, but otherwise it's the output directly from the build.

<img width="599" height="407" alt="image" src="https://github.com/user-attachments/assets/a54c9171-90c4-4b9c-90d8-b410f855558b" />

<img width="605" height="410" alt="image" src="https://github.com/user-attachments/assets/c3118af0-d0ec-4ffd-a7e4-05f5324d9bef" />

This is with current JMdict + JMnedict, for 三貴:

<img width="708" height="473" alt="image" src="https://github.com/user-attachments/assets/185b2978-0037-454d-aa7f-7482750a1058" />

And this is with the JMdict without proper names from this change:

<img width="719" height="404" alt="image" src="https://github.com/user-attachments/assets/ac90fc86-29c3-44cc-9afa-59afddbc9deb" />

No more duplicate results, as desired.