### PR TITLE
Update README link in releases

### DIFF
--- a/.github/workflows/build-release-dictionaries.yaml
+++ b/.github/workflows/build-release-dictionaries.yaml
@@ -39,4 +39,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             This is an automated release of the dictionaries for ${{ steps.date.outputs.date }}.
-            For information on how to use these dictionaries, please see the [README](https://github.com/MarvNC/jmdict-yomitan).
+            For information on how to use these dictionaries, please see the [README](https://github.com/yomidevs/jmdict-yomitan).


### PR DESCRIPTION
I noticed the link in all the releases still points to Marv's repo. It redirects to this repo so it's not a functional problem, but this updates the link to directly point to the current repo instead.